### PR TITLE
Install latest ostruct to fix JSON parsing into an OpenStruct

### DIFF
--- a/action/install_gems.rb
+++ b/action/install_gems.rb
@@ -6,6 +6,7 @@ class GemfileStrategy
       source "https://rubygems.org"
 
       gem 'brakeman'
+      gem 'ostruct'
     end
   end
 end


### PR DESCRIPTION
The OpenStruct implementation differs between Ruby 2.7 and 3.1. The
latter comes with OpenStruct 0.5.2. That version has a bug that was
fixed [here](https://github.com/ruby/ostruct/pull/37).

The TL;DR of the impact of that bug in this repo is that brakeman
includes JSON with an attribute named `class`. This shadows the normal
`class` method and causes `self.class.ancestors` to blow up. The fix
uses the aliased `class!` method to do the Right Thing™.