### PR TITLE
Remove bundler-cache from sample config

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ jobs:
         with:
           fetch-depth: 0
       - uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
       - uses: planningcenter/balto-brakeman@v0.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This was added as a recommended part of the sample config, but it's not clear why it was added. That config runs `bundle install` and caches the installed gems. 

Since balto-brakeman does the work of only installing the minimum gems necessary for it to run (i.e. brakeman), also having a project do a full `bundle install` seems like extra work that's not needed, especially for larger apps.  A number of apps use brakeman without this option, and everything seems to work just fine.