### PR TITLE
docs: Updates from new tag release process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## Unreleased
+**Note:** changes since v0.5 can be found on the [releases page](https://github.com/planningcenter/balto-brakeman/releases)
 
 ## v0.5 (2022-07-06)
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: ruby/setup-ruby@v1
-      - uses: planningcenter/balto-brakeman@v0.5
+      - uses: planningcenter/balto-brakeman@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
This probably should have been in #9. It follows the same pattern we've done elsewhere.